### PR TITLE
change of simple-pid version and minor changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,10 +39,9 @@ build: init_submodules clean root_check docker_group_check _build ## Build build
 
 .PHONY: up
 up: ## Start carla, carla-ros-bridge and adore_if_carla docker images
-	xhost + 1> /dev/null && \
+	xhost local:root && \
     docker compose up --force-recreate -d adore_if_carla; \
-    xhost - 1> /dev/null; \
-    docker compose rm --force
+	docker compose rm --force
 
 .PHONY: down
 down: ## Stop carla, carla-ros-bridge and adore_if_carla docker images

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -50,7 +50,9 @@ services:
     container_name: adore_if_carla 
     depends_on:
       - carla-ros-bridge
-    command: /bin/bash -c "source /tmp/adore_if_carla/build/catkin_generated/installspace/setup.bash; roslaunch /tmp/adore_if_carla/launch/demo014_adore_if_carla_part.launch"
+    environment:
+      - DISPLAY=${DISPLAY}
+    command: /bin/bash -c "source /tmp/adore_if_carla/adore_if_carla/build/install/setup.bash; roslaunch --wait /tmp/adore_if_carla/adore_if_carla/launch/demo014_adore_if_carla_part.launch"
     #command: tail -F anything
     #stdin_open: true 
     #tty: true

--- a/docker/Dockerfile.ros-bridge
+++ b/docker/Dockerfile.ros-bridge
@@ -20,9 +20,11 @@ COPY ros-bridge_files/local /opt/carla-ros-bridge/launchfiles
 
 RUN /bin/bash -c 'source /opt/ros/noetic/setup.bash; \
     bash /opt/carla-ros-bridge/install_dependencies.sh; \
+    pip install --force-reinstall "simple-pid==1.0.1"; \
     sudo apt-get install --no-install-recommends -y librviz-dev; \
     echo "export PYTHONPATH=\$PYTHONPATH:/opt/carla/PythonAPI/carla/dist/$(ls /opt/carla/PythonAPI/carla/dist | grep py$ROS_PYTHON_VERSION.)" >> /opt/carla/setup.bash; \
     echo "export PYTHONPATH=\$PYTHONPATH:/opt/carla/PythonAPI/carla" >> /opt/carla/setup.bash'
+# reinstallation of specific version 1.0.1 of simple-pid is needed as naming convention changed in the following version 
 
 COPY external/ros-bridge /opt/carla-ros-bridge/src/
 COPY ros-bridge_files/local/settings.ros1.yaml /opt/carla-ros-bridge/src/carla_ackermann_control/config

--- a/files/requirements.adore_if_carla.build.ubuntu20.04.system
+++ b/files/requirements.adore_if_carla.build.ubuntu20.04.system
@@ -12,3 +12,5 @@ libzmq5
 libzmqpp-dev
 libzmqpp4
 
+xterm
+

--- a/install_nvidia_docker2.sh
+++ b/install_nvidia_docker2.sh
@@ -5,7 +5,7 @@ SCRIPT_DIRECTORY="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 check_distro() {
     distribution=$(awk -F= '/^NAME/{print $2}' /etc/os-release | tr -d '"')
-    if [ "$distribution" != "PUbuntu" ]; then
+    if [ "$distribution" != "Ubuntu" ]; then
         echo "Error: This script is intended for Ubuntu distributions only." >&2
         exit 1
     fi

--- a/launchfiles/demo014_adore_if_carla_part.launch
+++ b/launchfiles/demo014_adore_if_carla_part.launch
@@ -25,7 +25,7 @@
 
   <group ns="/vehicle0">
         <param name="PARAMS/adore_if_carla/carla_namespace" value="ego_vehicle"/>
-        <node name="vehiclestate_carla2adore" pkg="adore_if_carla" type="vehiclestate2adore_node" args="adore_automation_enabled" output="screen"/>
+        <node name="vehiclestate_carla2adore" pkg="adore_if_carla" type="vehiclestate2adore_node" args="adore_automation_enabled" launch-prefix="xterm -e" output="screen"/>
         <node name="ackermanncommand_adore2carla" pkg="adore_if_carla" type="ackermanncommand2carla_node" output="screen"/>
         <node name="objects_carla2adore" pkg="adore_if_carla" type="objects2adore_node" output="screen"/>
         <node name="plot_longitudinal_control_info" pkg="adore_if_carla" type="plot_longitudinal_control_info_node" output="screen"/>


### PR DESCRIPTION
The new simple-pid version 2.0 has changed naming convention and leads to an error with the carla-ros-bridge. This PR installs the specific version 1.0.1 and introduces some other minor changes.